### PR TITLE
Only write debug messages if descriptor is set

### DIFF
--- a/dht.c
+++ b/dht.c
@@ -325,9 +325,10 @@ static void
 debugf(const char *format, ...)
 {
     va_list args;
+    if(!dht_debug)
+        return;
     va_start(args, format);
-    if(dht_debug)
-        vfprintf(dht_debug, format, args);
+    vfprintf(dht_debug, format, args);
     va_end(args);
     fflush(dht_debug);
 }


### PR DESCRIPTION
fflush() flushes all open descriptors in case NULL is passed as argument. This patch prevents calls to fflush in case debug file descriptor is not initialized.

See also: https://trac.transmissionbt.com/ticket/4531.
