### PR TITLE
Use _WIN32 instead of WIN32 to check for Windows

### DIFF
--- a/dht.c
+++ b/dht.c
@@ -40,7 +40,7 @@ THE SOFTWARE.
 #include <fcntl.h>
 #include <sys/time.h>
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <arpa/inet.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -63,7 +63,7 @@ THE SOFTWARE.
 #define MSG_CONFIRM 0
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #define EAFNOSUPPORT WSAEAFNOSUPPORT
 static int


### PR DESCRIPTION
MinGW defines both _WIN32 and WIN32 (and may even be the only compiler
doing so). Microsoft and Intel compilers only define _WIN32. Use the
common one to eliminate the need in defining WIN32 explicitly.
