### PR TITLE
Removed crypt dependancy from Makefile for OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 CFLAGS = -g -Wall
-LDLIBS = -lcrypt
+
+ifneq ($(shell uname -s),Darwin)
+  LDLIBS = -lcrypt
+endif
 
 dht-example: dht-example.o dht.o
 


### PR DESCRIPTION
Fixes crypt library linking for OS X.

> $ make
> ...
> 1 warning generated.
> cc   dht-example.o dht.o  -lcrypt -o dht-example
> ld: library not found for -lcrypt
> clang: error: linker command failed with exit code 1 (use -v to see invocation)
> make: **\* [dht-example] Error 1

See https://developer.apple.com/library/mac/documentation/porting/conceptual/portingunix/compiling/compiling.html for more info.

> The linker flag -lcrypt is not supported in OS X.
