### PR TITLE
Improve compilation on Windows

### DIFF
--- a/dht.c
+++ b/dht.c
@@ -36,19 +36,25 @@ THE SOFTWARE.
 #include <errno.h>
 #include <string.h>
 #include <stdarg.h>
+
+#ifndef _WIN32
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/time.h>
 
-#ifndef _WIN32
 #include <arpa/inet.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #else
-#include <w32api.h>
-#define WINVER WindowsXP
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0501 /* Windows XP */
+#endif
+#ifndef WINVER
+#define WINVER _WIN32_WINNT
+#endif
 #include <ws2tcpip.h>
+#include <windows.h>
 #endif
 
 #include "dht.h"
@@ -65,7 +71,9 @@ THE SOFTWARE.
 
 #ifdef _WIN32
 
+#undef EAFNOSUPPORT
 #define EAFNOSUPPORT WSAEAFNOSUPPORT
+
 static int
 set_nonblocking(int fd, int nonblocking)
 {
@@ -83,7 +91,16 @@ random(void)
 {
     return rand();
 }
+
+/* Windows Vista and later already provide the implementation. */
+#if _WIN32_WINNT < 0x0600
 extern const char *inet_ntop(int, const void *, char *, socklen_t);
+#endif
+
+#ifdef _MSC_VER
+/* There is no snprintf in MSVCRT. */
+#define snprintf _snprintf
+#endif
 
 #else
 


### PR DESCRIPTION
MSVC doesn't provide unistd.h and sys/time.h. Another header, fcntl.h,
althought provided is not used during compilation.

MSVC doesn't provide w32api.h header (and WindowsXP macro), but it is
safe to assume that 0x0501 will represent Windows XP for the time being.
Also, MSVC and MinGW define both WINVER and (newer) _WIN32_WINNT macros
(and also NTDDI_VERSION, but that's whole other story), so both should
be overridden to support Windows XP.

MSVC and MinGW define their own EAFNOSUPPORT macro, which leads to
redefinition warning.

MSVC and MinGW provide declaration (and Windows provides implementation)
of inet_ntop function starting with Windows Vista.

MSVC doesn't provide snprintf function, but has _snprintf instead with
same signature and purpose.

Tested on Windows 7 with MSVC 2013 and MinGW 4.9.2, defining _WIN32_WINNT
and WINVER to 0x0501 and 0x0600.