### PR TITLE
Add CMakeLists to DHT library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.0)
+project(dht)
+
+#============================================================================
+# Internal compiler options
+#============================================================================
+
+option(DHT_BUILD_EXAMPLE "Build DHT example code" OFF)
+
+#============================================================================
+# Compile targets
+#============================================================================
+
+add_library(${PROJECT_NAME} STATIC dht.c dht.h)
+target_include_directories(dht PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(DHT_BUILD_EXAMPLE)
+	add_executable(${PROJECT_NAME}-example dht-example.c)
+	target_link_libraries(${PROJECT_NAME}-example dht)
+	target_link_libraries(${PROJECT_NAME}-example crypt)
+endif()


### PR DESCRIPTION
Now more and more projects use CMake as their build system. With this file, you can use add_subdirectory function to add DHT library to your project and use it the natural way.