### PR TITLE
Fixed const-correctness for sockaddr on dht_ping_node

### DIFF
--- a/dht.c
+++ b/dht.c
@@ -2340,7 +2340,7 @@ dht_insert_node(const unsigned char *id, struct sockaddr *sa, int salen)
 }
 
 int
-dht_ping_node(struct sockaddr *sa, int salen)
+dht_ping_node(const struct sockaddr *sa, int salen)
 {
     unsigned char tid[4];
 

--- a/dht.h
+++ b/dht.h
@@ -39,7 +39,7 @@ extern FILE *dht_debug;
 
 int dht_init(int s, int s6, const unsigned char *id, const unsigned char *v);
 int dht_insert_node(const unsigned char *id, struct sockaddr *sa, int salen);
-int dht_ping_node(struct sockaddr *sa, int salen);
+int dht_ping_node(const struct sockaddr *sa, int salen);
 int dht_periodic(const void *buf, size_t buflen,
                  const struct sockaddr *from, int fromlen,
                  time_t *tosleep, dht_callback *callback, void *closure);


### PR DESCRIPTION
dht_ping_node doesn't require a mutable sockaddr structure, so it is better to make it const.