### PR TITLE
dht-example compilation fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS = -g -Wall
-LDLIBS = -lcrypt
+
 
 dht-example: dht-example.o dht.o
 

--- a/dht-example.c
+++ b/dht-example.c
@@ -315,8 +315,12 @@ main(int argc, char **argv)
        a dump) and you already know their ids, it's better to use
        dht_insert_node.  If the ids are incorrect, the DHT will recover. */
     for(i = 0; i < num_bootstrap_nodes; i++) {
-        dht_ping_node((struct sockaddr*)&bootstrap_nodes[i],
-                      sizeof(bootstrap_nodes[i]));
+        socklen_t salen;
+        if(bootstrap_nodes[i].ss_family == AF_INET)
+            salen = sizeof(struct sockaddr_in);
+        else
+            salen = sizeof(struct sockaddr_in6);
+        dht_ping_node((struct sockaddr*)&bootstrap_nodes[i],  salen);
         usleep(random() % 100000);
     }
 

--- a/dht-example.c
+++ b/dht-example.c
@@ -1,9 +1,6 @@
 /* This example code was written by Juliusz Chroboczek.
    You are free to cut'n'paste from it to your heart's content. */
 
-/* For crypt */
-#define _GNU_SOURCE
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>

--- a/dht-example.c
+++ b/dht-example.c
@@ -318,7 +318,7 @@ main(int argc, char **argv)
             salen = sizeof(struct sockaddr_in);
         else
             salen = sizeof(struct sockaddr_in6);
-        dht_ping_node((struct sockaddr*)&bootstrap_nodes[i],  salen);
+        dht_ping_node((struct sockaddr*)&bootstrap_nodes[i], salen);
         usleep(random() % 100000);
     }
 

--- a/dht-example.c
+++ b/dht-example.c
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <signal.h>
 #include <sys/signal.h>
 
 #include "dht.h"


### PR DESCRIPTION
Compilation fixes for dht-example.c, and a bug fix for the socket address length (on my platform, passing `sizeof(sockaddr_storage)` to `sendto` gives `EINVAL`)