### PR TITLE
Extend dht-example

### DIFF
--- a/dht-example.sh
+++ b/dht-example.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Determine path of script
+BASEDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Pick random port number from range 1024-65535
+port=0
+while (( port < 1024 || port > 65535 )); do
+    port=$(($RANDOM + $RANDOM))
+done
+echo "Choosing random port '${port}'"
+
+# Lookup well-known bootstrap nodes and add results to command line
+BSNODES=(
+    router.bittorrent.com:6881
+    router.utorrent.com:6881
+    dht.transmissionbt.com:6881
+    dht.aelitis.com:6881
+    dht.libtorrent.org:25401
+    #router.bitcomet.com:6881   # does not seem to be active anymore
+    #router.bitcomet.net:554    # resolves to localhost (?)
+)
+nodeargs=()
+for ((i=0; i < ${#BSNODES[@]}; ++i)); do
+    echo "Loooking up bootstrap node '${BSNODES[i]}':"
+    readarray -d ":" -t hostinfo <<< "${BSNODES[i]}"
+    while read -r line; do
+        if [[ "${line}" =~ ^([0-9a-f.:]+)[[:space:]]+DGRAM$ ]]; then
+            echo "${line}"
+            nodeargs+=("${BASH_REMATCH[1]}" "${hostinfo[1]}")
+        fi
+    done < <(getent ahosts "${hostinfo[0]}")
+done
+
+# Run example
+echo "Running dht-example:"
+echo "# dht-example" ${port} ${nodeargs[@]}
+"${BASEDIR}"/dht-example ${port} ${nodeargs[@]}


### PR DESCRIPTION
**Extensions to example (`dht-example.c`):**
- more debugging output (bootstrap, bind, stats etc.)
- highlighted debugging output
- support for keyboard input

**New wrapper script (`dht-example.sh`):**
The script is intended to help users who just get started with your library and/or DHT and don't know how to use it, especially how to bootstrap:
- choose random port
- look up well-known bootstrap nodes
- generate and print command line for `dht-example`
- run `dht-example`

More stuff I could contribute in case you are interested (already implementing/testing):
- more detailed debug messages (to include nodes addresses, ids etc.)
- extract v-id from messages (client id, major version, minor version)
- add save/restore state to/from file on exit/startup
- enhance bootstrapping mechanism (see #34)

This library is great - well written, well documented, and providing a working example.
Very good work :+1:  I'm going to use it in my current project, a Qt-based torrent client.