### PR TITLE
fix new_search function to return NULL when no search slots are available

### DIFF
--- a/dht.c
+++ b/dht.c
@@ -1294,8 +1294,8 @@ new_search(void)
         }
     }
 
-    /* Oh, well, never mind.  Reuse the oldest slot. */
-    return oldest;
+    /* No available slots found, return NULL. */
+    return NULL;
 }
 
 /* Insert the contents of a bucket into a search structure. */


### PR DESCRIPTION
The README mentions that dht_search returns -1 when too many searches
are already in progress but it could never happen because in that case
new_search was always returning the slot of a search that was still in
progress instead of returning NULL.