### PR TITLE
Add CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.10)
+project(dht C)
+
+add_library(${PROJECT_NAME} STATIC
+    dht.c
+)
+
+install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+install(FILES dht.h DESTINATION include/dht)


### PR DESCRIPTION
Adding CMake support to help build it on Linux. Various projects might find it useful for simplifying their scripts. Notably, this is a requisite for Transmission.